### PR TITLE
fix label separation for speed chart

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,8 @@ var speedSpec = {
         axis: {
           title: 'Local Time',
           titleFontSize: 15,
-          labelFontSize: 18
+          labelFontSize: 18,
+          labelSeparation: 3
         }
       },
       y: {
@@ -212,8 +213,7 @@ var speedSpec = {
           format: ".1f",
           title: 'Avg. wind & Gust m/s',
           titleFontSize: 15,
-          labelFontSize: 18,
-          labelSeparation: 3
+          labelFontSize: 18
         }
       }
     }


### PR DESCRIPTION
set label separation on X axis instead of Y, to keep it consistent with 2 other charts